### PR TITLE
Limit deploy step of deploy.yml to NCAR/CUPiD repo on main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.repository == 'NCAR/CUPiD' && github.ref == 'refs/heads/main'
 
     environment:
       # makes sure the deployment shows up under "deployments" section on main github page


### PR DESCRIPTION
Addresses #53

Summary of changes:
- adds if check to make sure the action will only try to deploy from `NCAR/CUPiD` on main branch

See [action run from my fork](https://github.com/anissa111/CUPiD/actions/runs/7589617473) where the action returns success, but has skipped the deployment step.