### PR TITLE
Pin ADF to hash 4625c8a

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,6 +1,6 @@
 [ADF]
 local_path = externals/ADF
-branch = main
+hash = 4625c8a
 protocol = git
 repo_url = https://github.com/NCAR/ADF.git
 required = True


### PR DESCRIPTION
Later commits to ADF break the adf_quick_run notebook

This is a temporary workaround for #83 while we figure out what the permanent fix should be