### PR TITLE
Add pre-commit to cupid-dev

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,6 +1,6 @@
 ### All Submissions:
 
-* [ ] Have you followed the guidelines in our Contributing document (including the `pre-commit` check)?
+* [ ] Have you followed the guidelines in our Contributer's Guide](https://github.com/NCAR/CUPiD/wiki/Contributor's-Guide) (including the `pre-commit` check)?
 * [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
 
 <!-- You can erase any parts of this template not applicable to your Pull Request. -->

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,6 +1,6 @@
 ### All Submissions:
 
-* [ ] Have you followed the guidelines in our Contributing document?
+* [ ] Have you followed the guidelines in our Contributing document (including the `pre-commit` check)?
 * [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
 
 <!-- You can erase any parts of this template not applicable to your Pull Request. -->

--- a/README.md
+++ b/README.md
@@ -40,10 +40,16 @@ If you do not have `mamba` installed, you can still use `conda`... it will just 
 1. If `./manage_externals/checkout_externals` is not found, run `git submodule update --init` to clone the submodule.
 1. If `which cupid-run` returned the error `which: no cupid-run in ($PATH)`, then please run the following:
 
-``` bash
-$ conda activate cupid-dev
-$ pip install -e .  # installs cupid
-```
+   ``` bash
+   $ conda activate cupid-dev
+   $ pip install -e .  # installs cupid
+   ```
+
+1. If you plan on contributing code to CUPiD,
+whether developing CUPiD itself or providing notebooks for CUPiD to run,
+please see the [Contributer's Guide](https://github.com/NCAR/CUPiD/wiki/Contributor's-Guide).
+Note that CUPiD uses `pre-commit` to ensure code formatting guidelines are followed,
+and pull requests will not be accepted if they fail the `pre-commit`-based Github Action.
 
 ## Running
 

--- a/environments/dev-environment.yml
+++ b/environments/dev-environment.yml
@@ -12,6 +12,7 @@ dependencies:
     - nco
     - pandas
     - papermill
+    - pre-commit
     - pip
     - ploomber=0.22.3
     - pyyaml


### PR DESCRIPTION
I think we want to encourage the workflow of

1. checking out `CUPiD`
2. creating `cupid-dev` and `cupid-analysis`
3. activating `cupid-dev` and running `pre-commit install`
4. always running `git commit` from `(cupid-dev)`