### PR TITLE
Minor update to NCAR_tips.md to remove config.yml

### DIFF
--- a/NCAR_tips.md
+++ b/NCAR_tips.md
@@ -12,7 +12,7 @@ The recommended approach releases the cores immediately after `cupid-run` finish
 
 ```
 [login-node] $ conda activate cupid-dev
-(cupid-dev) [login-node] $ qcmd -l select=1:ncpus=12:mem=120GB -- cupid-run config.yml
+(cupid-dev) [login-node] $ qcmd -l select=1:ncpus=12:mem=120GB -- cupid-run
 ```
 
 Alternatively, you can start an interactive session and remain on the compute nodes after `cupid-run` completes:
@@ -20,7 +20,7 @@ Alternatively, you can start an interactive session and remain on the compute no
 ```
 [login-node] $ qinteractive -l select=1:ncpus=12:mem=120GB
 [compute-node] $ conda activate cupid-dev
-(cupid-dev) [compute-node] $ cupid-run config.yml
+(cupid-dev) [compute-node] $ cupid-run
 ```
 
 Notes:


### PR DESCRIPTION
I just noticed we didn't update the NCAR tips README when we changed the formatting for how to run cupid with `cupid-run`