### PR TITLE
Add new example for generating key metrics

### DIFF
--- a/examples/key_metrics/config.yml
+++ b/examples/key_metrics/config.yml
@@ -1,0 +1,203 @@
+################## SETUP ##################
+
+################
+# Data Sources #
+################
+data_sources:
+    # sname is any string used as a nickname for this configuration. It will be
+    ### used as the name of the folder your computed notebooks are put in
+    sname: key_metrics
+
+    # run_dir is the path to the folder you want
+    ### all the files associated with this configuration
+    ### to be created in
+    run_dir: .
+
+    # nb_path_root is the path to the folder that cupid will
+    ### look for your template notebooks in. It doesn't have to
+    ### be inside run_dir, or be specific to this project, as
+    ### long as the notebooks are there
+    nb_path_root: ../nblibrary
+
+######################
+# Computation Config #
+######################
+
+computation_config:
+
+    # default_kernel_name is the name of the environment that
+    ### the notebooks in this configuration will be run in by default.
+    ### It must already be installed on your machine. You can also
+    ### specify a different environment than the default for any
+    ### notebook in NOTEBOOK CONFIG
+
+    default_kernel_name: cupid-analysis
+
+############# NOTEBOOK CONFIG #############
+
+############################
+# Notebooks and Parameters #
+############################
+
+# All parameters under global_params get passed to all the notebooks
+
+global_params:
+  case_name: 'b.e23_alpha16b.BLT1850.ne30_t232.092'
+  CESM_output_dir: /glade/campaign/cesm/development/cross-wg/diagnostic_framework/CESM_output_for_testing
+  lc_kwargs:
+    threads_per_worker: 1
+
+timeseries:
+  num_procs: 8
+  ts_done: [False]
+  overwrite_ts: [False]
+  case_name: 'b.e23_alpha16b.BLT1850.ne30_t232.092'
+
+  atm:
+    vars: ['ACTNI', 'ACTNL', 'ACTREI', 'ACTREL', 'AODDUST']
+    derive_vars: [] # {'PRECT':['PRECL', 'PRECC'], 'RESTOM':['FLNT', 'FSNT']}
+    hist_str: 'h0'
+    start_years: [1]
+    end_years: [100]
+    level: 'lev'
+
+  lnd:
+    vars: ['ALTMAX', 'COST_NACTIVE', 'DENIT', 'EFLX_DYNBAL']  #['process_all']
+    derive_vars: []
+    hist_str: 'h0'
+    start_years: [1]
+    end_years: [100]
+    level: 'lev'
+
+  ocn:
+    vars: ['taux', 'tauy'] # ['process_all']
+    derive_vars: []
+    hist_str: 'h.frc'
+    start_years: [1]
+    end_years: [100]
+    level: 'lev'
+
+  ice:
+    vars: ['hi', 'hs', 'snowfrac', 'Tsfc'] #['process_all']
+    derive_vars: []
+    hist_str: 'h'
+    start_years: [1]
+    end_years: [100]
+    level: 'lev'
+
+  glc:
+    vars: ['usurf', 'topg'] #['process_all']
+    derive_vars: []
+    hist_str: 'initial_hist'
+    start_years: [1]
+    end_years: [100]
+    level: 'lev'
+
+compute_notebooks:
+
+  # This is where all the notebooks you want run and their
+  # parameters are specified. Several examples of different
+  # types of notebooks are provided.
+
+  # The first key (here simple_no_params_nb) is the name of the
+  # notebook from nb_path_root, minus the .ipynb
+
+    infrastructure:
+      index:
+        parameter_groups:
+          none: {}
+
+#    atm:
+#      adf_quick_run:
+#        parameter_groups:
+#          none:
+#            adf_path: ../../../externals/ADF
+#            config_path: .
+#            config_fil_str: "config_f.cam6_3_119.FLTHIST_ne30.r328_gamma0.33_soae.001.yaml"
+
+#    ocn:
+#      ocean_surface:
+#        parameter_groups:
+#          none:
+#            Case: b.e23_alpha16b.BLT1850.ne30_t232.054
+#            savefigs: False
+#            mom6_tools_config:
+#              start_date: '0091-01-01'
+#              end_date: '0101-01-01'
+#              Fnames:
+#                native: 'mom6.h.native.????-??.nc'
+#                static: 'mom6.h.static.nc'
+#              oce_cat: /glade/u/home/gmarques/libs/oce-catalogs/reference-datasets.yml
+
+#    lnd:
+#      land_comparison:
+#        parameter_groups:
+#          none:
+#            cases:
+#              - ctsm51d159_f45_GSWP3_bgccrop_1850pAD
+#              - ctsm51d159_f45_GSWP3_bgccrop_1850pSASU
+#            type:
+#              - 1850pAD
+#              - 1850pSASU
+
+#    ice:
+#      seaice:
+#        parameter_groups:
+#          none:
+#            cases:
+#              - g.e23_a16g.GJRAv4.TL319_t232_hycom1_N75.2024.005
+#              - g.e23_a16g.GJRAv4.TL319_t232_zstar_N65.2024.004
+#            begyr1: 245
+#            endyr1: 305
+#            begyr2: 245
+#            endyr2: 305
+#            nyears: 25
+
+########### JUPYTER BOOK CONFIG ###########
+
+##################################
+# Jupyter Book Table of Contents #
+##################################
+book_toc:
+
+  # See https://jupyterbook.org/en/stable/structure/configure.html for
+  # complete documentation of Jupyter book construction options
+
+  format: jb-book
+
+  # All filenames are notebook filename without the .ipynb, similar to above
+
+  root: infrastructure/index # root is the notebook that will be the homepage for the book
+  parts:
+
+    # Parts group notebooks into different sections in the Jupyter book
+    # table of contents, so you can organize different parts of your project.
+
+    - caption: Atmosphere
+
+      # Each chapter is the name of one of the notebooks that you executed
+      # in compute_notebooks above, also without .ipynb
+      chapters:
+        - file: atm/adf_quick_run
+
+    - caption: Ocean
+      chapters:
+          - file: ocn/ocean_surface
+
+    - caption: Land
+      chapters:
+        - file: lnd/land_comparison
+
+    - caption: Sea Ice
+      chapters:
+        - file: ice/seaice
+
+#####################################
+# Keys for Jupyter Book _config.yml #
+#####################################
+book_config_keys:
+
+  title: Example project   # Title of your jupyter book
+
+  # Other keys can be added here, see https://jupyterbook.org/en/stable/customize/config.html
+  ### for many more options

--- a/examples/key_metrics/config.yml
+++ b/examples/key_metrics/config.yml
@@ -51,7 +51,7 @@ timeseries:
   num_procs: 8
   ts_done: [False]
   overwrite_ts: [False]
-  case_name: 'b.e23_alpha16b.BLT1850.ne30_t232.092'
+  case_name: 'b.e23_alpha17f.BLT1850.ne30_t232.092'
 
   atm:
     vars: ['ACTNI', 'ACTNL', 'ACTREI', 'ACTREL', 'AODDUST']

--- a/examples/key_metrics/config.yml
+++ b/examples/key_metrics/config.yml
@@ -42,7 +42,7 @@ computation_config:
 # All parameters under global_params get passed to all the notebooks
 
 global_params:
-  case_name: 'b.e23_alpha16b.BLT1850.ne30_t232.092'
+  case_name: 'b.e23_alpha17f.BLT1850.ne30_t232.092'
   CESM_output_dir: /glade/campaign/cesm/development/cross-wg/diagnostic_framework/CESM_output_for_testing
   lc_kwargs:
     threads_per_worker: 1


### PR DESCRIPTION
The goal of this config file is to specify a case and compute a handful of key metrics as defined by in the CESM project meeting. (It may be the case that these key metrics require comparing to other CESM runs or observations.)