### PR TITLE
Observational data common location

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,3 +6,4 @@
 * [ ] Have you [hidden the code cells (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html) in your notebook?
 * [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
 * [ ] Have you successfully tested your changes locally?
+* [ ] Have you moved any observational data that you are using to `/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data` and ensured that it follows this format within that directory: `COMPONENT/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE`?

--- a/examples/key_metrics/config.yml
+++ b/examples/key_metrics/config.yml
@@ -142,7 +142,7 @@ compute_notebooks:
       Greenland_SMB_visual_compare_obs:
         parameter_groups:
           none:
-            obs_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/ice/analysis_datasets/multi_grid/annual_avg/SMB_data'
+            obs_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/glc/analysis_datasets/multi_grid/annual_avg/SMB_data'
             obs_name: 'GrIS_MARv3.12_climo_1960_1999.nc'
             climo_nyears: 40
 

--- a/examples/key_metrics/config.yml
+++ b/examples/key_metrics/config.yml
@@ -125,7 +125,7 @@ compute_notebooks:
           none:
             regridded_output: False # it looks like output is already on f09 grid, didn't need to regrid time-series file
             base_regridded_output: True
-            validation_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/atm/analysis_datasets/fv0.9x1.25/PROCESSED_FIELD_TYPE/nmse_validation/'
+            validation_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/atm/analysis_datasets/fv0.9x1.25/seasonal_climatology/nmse_validation/PSL/'
       link_to_ADF:
         kernel_name: cupid-infrastructure
         parameter_groups:
@@ -142,7 +142,7 @@ compute_notebooks:
       Greenland_SMB_visual_compare_obs:
         parameter_groups:
           none:
-            obs_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/ice/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE/SMB_data/'
+            obs_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/ice/analysis_datasets/multi_grid/annual_avg/SMB_data/'
             obs_name: 'GrIS_MARv3.12_climo_1960_1999.nc'
             climo_nyears: 40
 
@@ -176,7 +176,7 @@ compute_notebooks:
           none:
             clmFile_h: '.h0.'
             fluxnet_comparison: True
-            obsDir: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/ice/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE/FLUXNET2015/'
+            obsDir: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/ice/analysis_datasets/ungridded/timeseries/FLUXNET2015/'
 
 #    ocn:
 #      ocean_surface:

--- a/examples/key_metrics/config.yml
+++ b/examples/key_metrics/config.yml
@@ -176,7 +176,7 @@ compute_notebooks:
           none:
             clmFile_h: '.h0.'
             fluxnet_comparison: True
-            obsDir: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/ice/analysis_datasets/ungridded/timeseries/FLUXNET2015/'
+            obsDir: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/lnd/analysis_datasets/ungridded/timeseries/FLUXNET2015/'
 
 #    ocn:
 #      ocean_surface:

--- a/examples/key_metrics/config.yml
+++ b/examples/key_metrics/config.yml
@@ -142,7 +142,7 @@ compute_notebooks:
       Greenland_SMB_visual_compare_obs:
         parameter_groups:
           none:
-            obs_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/ice/analysis_datasets/multi_grid/annual_avg/SMB_data/'
+            obs_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/ice/analysis_datasets/multi_grid/annual_avg/SMB_data'
             obs_name: 'GrIS_MARv3.12_climo_1960_1999.nc'
             climo_nyears: 40
 

--- a/examples/key_metrics/config.yml
+++ b/examples/key_metrics/config.yml
@@ -125,7 +125,7 @@ compute_notebooks:
           none:
             regridded_output: False # it looks like output is already on f09 grid, didn't need to regrid time-series file
             base_regridded_output: True
-            validation_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/nmse_validation/fv0.9x1.25'
+            validation_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/atm/analysis_datasets/fv0.9x1.25/PROCESSED_FIELD_TYPE/nmse_validation/'
       link_to_ADF:
         kernel_name: cupid-infrastructure
         parameter_groups:
@@ -142,7 +142,7 @@ compute_notebooks:
       Greenland_SMB_visual_compare_obs:
         parameter_groups:
           none:
-            obs_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/SMB_data'
+            obs_path: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/ice/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE/SMB_data/'
             obs_name: 'GrIS_MARv3.12_climo_1960_1999.nc'
             climo_nyears: 40
 
@@ -176,7 +176,7 @@ compute_notebooks:
           none:
             clmFile_h: '.h0.'
             fluxnet_comparison: True
-            obsDir: '/glade/campaign/cgd/tss/people/mdfowler/FLUXNET2015/'
+            obsDir: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data/ice/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE/FLUXNET2015/'
 
 #    ocn:
 #      ocean_surface:


### PR DESCRIPTION
This PR will address #166 .

We have created a directory (`/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data`) for cupid observational data. Existing data should be moved here to assist with organizing data as we move towards an obs data repo. New CUPiD related data should follow this format, hence the PR template update that requests data follows the format `COMPONENT/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE`.

TODO:
* [x] Update key metric config file obs data paths
    * [x] /glade/campaign/cesm/development/cross-wg/diagnostic_framework/nmse_validation/fv0.9x1.25 (Isla)
    * [x] /glade/campaign/cesm/development/cross-wg/diagnostic_framework/SMB_data (Gunter)
    * [x] /glade/campaign/cgd/tss/people/mdfowler/FLUXNET2015/ (Meg)
* [x] Check with relevant parties about location of data and ability to move it
* [x] Move existing data

Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/ContributorGuide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully tested your changes locally?
