### PR TITLE
Fix ILAMB installation error

### DIFF
--- a/environments/cupid-analysis.yml
+++ b/environments/cupid-analysis.yml
@@ -27,4 +27,4 @@ dependencies:
   - zarr
   - pip:
     - -e ../externals/mom6-tools
-      - git+https://github.com/rubisco-sfa/ILAMB.git
+    - git+https://github.com/rubisco-sfa/ILAMB.git


### PR DESCRIPTION
### Description of changes:
There was an extra tab in front of the ILAMB installation line in cupid-analysis.yml, so ILAMB wasn't installing properly.

* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/ContributorGuide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully tested your changes locally?