### PR TITLE
Fix timeseries import

### DIFF
--- a/cupid/clean.py
+++ b/cupid/clean.py
@@ -15,7 +15,10 @@ import shutil
 
 import click
 
-import cupid.util
+try:
+    import util
+except ModuleNotFoundError:
+    import cupid.util as util
 
 
 def read_config_file(config_path):
@@ -30,7 +33,7 @@ def read_config_file(config_path):
         None
     """
     # Obtain the contents of the configuration file and extract the run_dir variable
-    control = cupid.util.get_control_dict(config_path)
+    control = util.get_control_dict(config_path)
     run_dir = control["data_sources"].get("run_dir", None)
 
     if run_dir:
@@ -52,7 +55,7 @@ def clean(config_path):
     Args: CONFIG_PATH - The path to the configuration file.
 
     """
-    logger = cupid.util.setup_logging(config_path)
+    logger = util.setup_logging(config_path)
     run_dir = read_config_file(config_path)
     # Delete the "computed_notebooks" folder and all the contents inside of it
     shutil.rmtree(run_dir)

--- a/cupid/run_diagnostics.py
+++ b/cupid/run_diagnostics.py
@@ -28,7 +28,10 @@ import click
 import intake
 import ploomber
 
-import cupid.util
+try:
+    import util
+except ModuleNotFoundError:
+    import cupid.util as util
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -70,9 +73,9 @@ def run_diagnostics(
     # fmt: on
     # pylint: enable=line-too-long
     # Get control structure
-    control = cupid.util.get_control_dict(config_path)
-    cupid.util.setup_book(config_path)
-    logger = cupid.util.setup_logging(config_path)
+    control = util.get_control_dict(config_path)
+    util.setup_book(config_path)
+    logger = util.setup_logging(config_path)
 
     component_options = {
         "atm": atmosphere,
@@ -182,7 +185,7 @@ def run_diagnostics(
         # Setting up notebook tasks
 
         for nb, info in all_nbs.items():
-            cupid.util.create_ploomber_nb_task(
+            util.create_ploomber_nb_task(
                 nb,
                 info,
                 cat_path,
@@ -224,7 +227,7 @@ def run_diagnostics(
         # Setting up script tasks
 
         for script, info in all_scripts.items():
-            cupid.util.create_ploomber_script_task(
+            util.create_ploomber_script_task(
                 script,
                 info,
                 cat_path,

--- a/cupid/run_timeseries.py
+++ b/cupid/run_timeseries.py
@@ -25,8 +25,13 @@ from __future__ import annotations
 import os
 
 import click
-import timeseries
-import util
+
+try:
+    import timeseries
+    import util
+except ModuleNotFoundError:
+    import cupid.timeseries as timeseries
+    import cupid.util as util
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 


### PR DESCRIPTION
### Description of changes:

Fixes #175

`import timeseries` fails when invoking `cupid-timeseries`, but is valid when running `/path/to/CUPiD/cupid/run_timeseries.py` so I added a `try` / `except` block. There were imports of `cupid.util` in `run_diagnostics.py` and `clean.py` that I changed to this new structure.

* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/ContributorGuide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you [hidden the code cells (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html) in your notebook?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully tested your changes locally?
* [x] Have you moved any observational data that you are using to `/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data` and ensured that it follows this format within that directory: `COMPONENT/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE`?
