### PR TITLE
Update to v3 of actions/upload-pages-artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
 
       # Upload build directory for the deployment step
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './docs/_build/html/'
 


### PR DESCRIPTION
### Description of changes:

Fixes #178 (I hope)
Our Build and Deploy workflow was using `actions/upload-pages-artifact@v2`, which was failing with a link to [this deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). This PR updates to `actions/upload-pages-artifact@v3`, and I'm cautiously optimistic that the existing `with:` and `path:` are still part of the API for the updated version. I don't know if there's a way to test the workflow ahead of time, or if we just merge this in and hope the failing action starts to pass...

* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/ContributorGuide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you [hidden the code cells (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html) in your notebook?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully tested your changes locally?
* [x] Have you moved any observational data that you are using to `/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data` and ensured that it follows this format within that directory: `COMPONENT/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE`?
