### PR TITLE
Update instructions in link_to_ADF.ipynb

### DIFF
--- a/nblibrary/atm/link_to_ADF.ipynb
+++ b/nblibrary/atm/link_to_ADF.ipynb
@@ -14,7 +14,7 @@
     "1) Install ADF\n",
     "2) Use the `CUPiD/helper_scripts/generate_adf_config_file.py` script to generate an ADF config file based on a CUPiD configuration file.\n",
     "   * `cd CUPiD/helper_scripts`\n",
-    "   * `./generate_adf_config_file.py --cupid_file ../examples/external_diag_packages/config.yml --adf_template ../../ADF/config_amwg_default_plots.yaml --out_file ../../ADF_config.yaml`\n",
+    "   * `generate_adf_config_file.py --cesm-root $CESM_ROOT --cupid-config-loc ../examples/external_diag_packages --adf-template ../../ADF/config_amwg_default_plots.yaml`\n",
     "4) Run ADF with the newly created configuration file.\n",
     "   * `cd ../../ADF`\n",
     "   * `./run_adf_diag ../ADF_config.yaml`"


### PR DESCRIPTION
### Description of changes:
The instructions in link_to_ADF.ipynb were out of date. With this PR, the notebook has instructions that correspond with the arguments that the ADF config file helper script currently uses.

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [ ] Have you successfully tested your changes locally?