### PR TITLE
Two cupid_webpage fixes

### DIFF
--- a/cupid/cupid_webpage.py
+++ b/cupid/cupid_webpage.py
@@ -22,9 +22,18 @@ import subprocess
 from urllib.parse import quote
 
 import click
-from git_helper import GitHelper
-from util import get_control_dict
-from util import is_bad_env
+
+try:
+    from git_helper import GitHelper
+except ModuleNotFoundError:
+    from cupid.git_helper import GitHelper
+
+try:
+    from util import get_control_dict
+    from util import is_bad_env
+except ModuleNotFoundError:
+    from cupid.util import get_control_dict
+    from cupid.util import is_bad_env
 
 
 def github_pages_publish(
@@ -149,8 +158,8 @@ def build(config_path, github_pages_dir, name, overwrite):
     control = get_control_dict(config_path)
 
     # Check and process arguments
-    github_pages_dir = os.path.realpath(github_pages_dir)
     if github_pages_dir:
+        github_pages_dir = os.path.realpath(github_pages_dir)
         github_pages_dir_thisversion, git_repo = github_pages_args(
             github_pages_dir,
             name,


### PR DESCRIPTION
1. Depending on how your environment is configured, you either need to import `util` or `cupid.util` (and `git_helper` or `cupid.git_helper`); added try / except blocks for both imports
2. Don't update `github_pages_dir` to a `realpath` unless it is non-empty (want to keep default behavior of not doing anything if user doesn't specify `-g` option; I was getting

```
RuntimeError: When specifying -g/--github-pages-dir, you must also provide -n/--name
```

even when not specifying `-g`)

### Description of changes:
* [x] Please add an explanation of what your changes do and why you'd like us to include them.

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally?
