### PR TITLE
Add client shutdown and move the subsetting to the numpy arrays.

### DIFF
--- a/nblibrary/ice/Hemis_seaice_visual_compare_contour.ipynb
+++ b/nblibrary/ice/Hemis_seaice_visual_compare_contour.ipynb
@@ -325,7 +325,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5199b36e-614d-4242-9dd0-a402a7a24fa9",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "client.shutdown()"

--- a/nblibrary/ice/Hemis_seaice_visual_compare_contour.ipynb
+++ b/nblibrary/ice/Hemis_seaice_visual_compare_contour.ipynb
@@ -327,7 +327,9 @@
    "id": "5199b36e-614d-4242-9dd0-a402a7a24fa9",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "client.shutdown()"
+   ]
   }
  ],
  "metadata": {

--- a/nblibrary/ice/Hemis_seaice_visual_compare_obs_lens.ipynb
+++ b/nblibrary/ice/Hemis_seaice_visual_compare_obs_lens.ipynb
@@ -219,8 +219,8 @@
     "ds1_ann = ds1.resample(time=\"YS\").mean(dim=\"time\")\n",
     "ds2_ann = ds2.resample(time=\"YS\").mean(dim=\"time\")\n",
     "\n",
-    "climo_nyears = min(climo_nyears, len(ds1_ann.time))\n",
-    "climo_nyears = min(climo_nyears, len(ds2_ann.time))\n",
+    "climo_nyears1 = min(climo_nyears, len(ds1_ann.time))\n",
+    "climo_nyears2 = min(climo_nyears, len(ds2_ann.time))\n",
     "\n",
     "with open(\"cice_masks.yml\", \"r\") as file:\n",
     "    cice_masks = yaml.safe_load(file)\n",
@@ -883,13 +883,13 @@
     "# get monthly means from test data\n",
     "aice1_month = (\n",
     "    ds1[\"aice\"]\n",
-    "    .isel(time=slice(-climo_nyears * 12, None))\n",
+    "    .isel(time=slice(-climo_nyears1 * 12, None))\n",
     "    .groupby(\"time.month\")\n",
     "    .mean(dim=\"time\", skipna=True)\n",
     ")\n",
     "aice2_month = (\n",
     "    ds2[\"aice\"]\n",
-    "    .isel(time=slice(-climo_nyears * 12, None))\n",
+    "    .isel(time=slice(-climo_nyears2 * 12, None))\n",
     "    .groupby(\"time.month\")\n",
     "    .mean(dim=\"time\", skipna=True)\n",
     ")"
@@ -1007,13 +1007,13 @@
     "# get monthly means from test data\n",
     "hi1_month = (\n",
     "    ds1[\"hi\"]\n",
-    "    .isel(time=slice(-climo_nyears * 12, None))\n",
+    "    .isel(time=slice(-climo_nyears1 * 12, None))\n",
     "    .groupby(\"time.month\")\n",
     "    .mean(dim=\"time\", skipna=True)\n",
     ")\n",
     "hi2_month = (\n",
     "    ds2[\"hi\"]\n",
-    "    .isel(time=slice(-climo_nyears * 12, None))\n",
+    "    .isel(time=slice(-climo_nyears2 * 12, None))\n",
     "    .groupby(\"time.month\")\n",
     "    .mean(dim=\"time\", skipna=True)\n",
     ")"
@@ -1137,13 +1137,13 @@
     "# get monthly means from test data\n",
     "hs1_month = (\n",
     "    ds1[\"hs\"]\n",
-    "    .isel(time=slice(-climo_nyears * 12, None))\n",
+    "    .isel(time=slice(-climo_nyears1 * 12, None))\n",
     "    .groupby(\"time.month\")\n",
     "    .mean(dim=\"time\", skipna=True)\n",
     ")\n",
     "hs2_month = (\n",
     "    ds2[\"hs\"]\n",
-    "    .isel(time=slice(-climo_nyears * 12, None))\n",
+    "    .isel(time=slice(-climo_nyears2 * 12, None))\n",
     "    .groupby(\"time.month\")\n",
     "    .mean(dim=\"time\", skipna=True)\n",
     ")"
@@ -1276,10 +1276,10 @@
    },
    "outputs": [],
    "source": [
-    "ds1_area = (tarea * ds1.aice).isel(time=slice(-climo_nyears * 12, None)).where(\n",
+    "ds1_area = (tarea * ds1.aice).isel(time=slice(-climo_nyears1 * 12, None)).where(\n",
     "    TLAT > 0\n",
     ").sum(dim=[\"nj\", \"ni\"]) * 1.0e-12\n",
-    "ds2_area = (tarea * ds2.aice).isel(time=slice(-climo_nyears * 12, None)).where(\n",
+    "ds2_area = (tarea * ds2.aice).isel(time=slice(-climo_nyears2 * 12, None)).where(\n",
     "    TLAT > 0\n",
     ").sum(dim=[\"nj\", \"ni\"]) * 1.0e-12"
    ]
@@ -1512,10 +1512,10 @@
    },
    "outputs": [],
    "source": [
-    "ds1_vol = (tarea * ds1.hi).isel(time=slice(-climo_nyears * 12, None)).where(\n",
+    "ds1_vol = (tarea * ds1.hi).isel(time=slice(-climo_nyears1 * 12, None)).where(\n",
     "    TLAT > 0\n",
     ").sum(dim=[\"nj\", \"ni\"]) * 1.0e-13\n",
-    "ds2_vol = (tarea * ds2.hi).isel(time=slice(-climo_nyears * 12, None)).where(\n",
+    "ds2_vol = (tarea * ds2.hi).isel(time=slice(-climo_nyears2 * 12, None)).where(\n",
     "    TLAT > 0\n",
     ").sum(dim=[\"nj\", \"ni\"]) * 1.0e-13"
    ]
@@ -1713,10 +1713,10 @@
    },
    "outputs": [],
    "source": [
-    "ds1_area = (tarea * ds1.aice).isel(time=slice(-climo_nyears * 12, None)).where(\n",
+    "ds1_area = (tarea * ds1.aice).isel(time=slice(-climo_nyears1 * 12, None)).where(\n",
     "    TLAT < 0\n",
     ").sum(dim=[\"nj\", \"ni\"]) * 1.0e-12\n",
-    "ds2_area = (tarea * ds2.aice).isel(time=slice(-climo_nyears * 12, None)).where(\n",
+    "ds2_area = (tarea * ds2.aice).isel(time=slice(-climo_nyears2 * 12, None)).where(\n",
     "    TLAT < 0\n",
     ").sum(dim=[\"nj\", \"ni\"]) * 1.0e-12"
    ]
@@ -1916,10 +1916,10 @@
    },
    "outputs": [],
    "source": [
-    "ds1_vol = (tarea * ds1.hi).isel(time=slice(-climo_nyears * 12, None)).where(\n",
+    "ds1_vol = (tarea * ds1.hi).isel(time=slice(-climo_nyears1 * 12, None)).where(\n",
     "    TLAT < 0\n",
     ").sum(dim=[\"nj\", \"ni\"]) * 1.0e-13\n",
-    "ds2_vol = (tarea * ds2.hi).isel(time=slice(-climo_nyears * 12, None)).where(\n",
+    "ds2_vol = (tarea * ds2.hi).isel(time=slice(-climo_nyears2 * 12, None)).where(\n",
     "    TLAT < 0\n",
     ").sum(dim=[\"nj\", \"ni\"]) * 1.0e-13"
    ]
@@ -2142,7 +2142,9 @@
    "id": "4b5a2683-61de-4a4d-8f22-d05d185977c2",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "client.shutdown()"
+   ]
   }
  ],
  "metadata": {

--- a/nblibrary/ice/Hemis_seaice_visual_compare_obs_lens.ipynb
+++ b/nblibrary/ice/Hemis_seaice_visual_compare_obs_lens.ipynb
@@ -2140,7 +2140,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4b5a2683-61de-4a4d-8f22-d05d185977c2",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "client.shutdown()"

--- a/nblibrary/ice/vect_diff.py
+++ b/nblibrary/ice/vect_diff.py
@@ -58,10 +58,10 @@ def vect_diff(uvel1, vvel1, uvel2, vvel2, angle, proj, case1, case2, TLAT, TLON)
     intv = 5
     # add vectors
     Q = ax.quiver(
-        TLON[::intv, ::intv].values,
-        TLAT[::intv, ::intv].values,
-        uvel_rot1[::intv, ::intv].values,
-        vvel_rot1[::intv, ::intv].values,
+        TLON.values[::intv, ::intv],
+        TLAT.values[::intv, ::intv],
+        uvel_rot1.values[::intv, ::intv],
+        vvel_rot1.values[::intv, ::intv],
         color="black",
         scale=1.0,
         transform=ccrs.PlateCarree(),
@@ -106,10 +106,10 @@ def vect_diff(uvel1, vvel1, uvel2, vvel2, angle, proj, case1, case2, TLAT, TLON)
     intv = 5
     # add vectors
     Q = ax.quiver(
-        TLON[::intv, ::intv].values,
-        TLAT[::intv, ::intv].values,
-        uvel_rot2[::intv, ::intv].values,
-        vvel_rot2[::intv, ::intv].values,
+        TLON.values[::intv, ::intv],
+        TLAT.values[::intv, ::intv],
+        uvel_rot2.values[::intv, ::intv],
+        vvel_rot2.values[::intv, ::intv],
         color="black",
         scale=1.0,
         transform=ccrs.PlateCarree(),
@@ -154,10 +154,10 @@ def vect_diff(uvel1, vvel1, uvel2, vvel2, angle, proj, case1, case2, TLAT, TLON)
     intv = 5
     # add vectors
     Q = ax.quiver(
-        TLON[::intv, ::intv].values,
-        TLAT[::intv, ::intv].values,
-        uvel_diff[::intv, ::intv].values,
-        vvel_diff[::intv, ::intv].values,
+        TLON.values[::intv, ::intv],
+        TLAT.values[::intv, ::intv],
+        uvel_diff.values[::intv, ::intv],
+        vvel_diff.values[::intv, ::intv],
         color="black",
         scale=1.0,
         transform=ccrs.PlateCarree(),


### PR DESCRIPTION
### Description of changes:
* [X] Please add an explanation of what your changes do and why you'd like us to include them.

Add the client.shutdown() commands move the subsetting in vect_diff.py to the values argument. These might have solved issue #186 
#### All PRs Checklist:
* [X] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [X] Have you successfully tested your changes locally?

#### New notebook PR Additional Checklist (if these do not apply, feel free to remove this section):
* [X] Have you [hidden the code cells (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html) in your notebook?
* [X] Have you removed any unused parameters from your cell tagged with `parameters`? These can cause confusing warnings that show up as `DAG build with warnings`.
* [X] Have you moved any observational data that you are using to `/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data` and ensured that it follows this format within that directory: `COMPONENT/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE`?
