### PR TITLE
Rof warning fix numpy function

### DIFF
--- a/nblibrary/rof/global_discharge_gauge_compare_obs.ipynb
+++ b/nblibrary/rof/global_discharge_gauge_compare_obs.ipynb
@@ -1035,7 +1035,7 @@
     "\n",
     "                # compute %bias, correlation, RMSE\n",
     "                bias[ix] = metric.pbias(q_sim, q_obs)\n",
-    "                corr[ix] = np.corrcoef(q_sim, q_obs)[0, 1]\n",
+    "                corr[ix] = metric.corr(q_sim, q_obs)\n",
     "                rmse[ix] = metric.rmse(qsim, qobs)\n",
     "\n",
     "        mon_pbias[case] = bias\n",

--- a/nblibrary/rof/scripts/metrics.py
+++ b/nblibrary/rof/scripts/metrics.py
@@ -31,6 +31,34 @@ def remove_nan(qsim, qobs):
     return sim_obs[:, 0], sim_obs[:, 1]
 
 
+def corr(qsim, qobs):
+    """
+    Calculates pearson correlation between two flow arrays.
+
+    Arguments
+    ---------
+    sim: array-like
+        Simulated time series array.
+    obs: array-like
+        Observed time series array.
+
+    Returns
+    -------
+    corr: float
+        Pearson correlation between the two arrays.
+    """
+    qsim1, qobs1 = remove_nan(qsim, qobs)
+    if qobs1.size <= 1:  # correlation cannot be computed with size 1 array
+        error_metric = np.nan
+    elif (
+        len(np.unique(qsim1)) == 1 or len(np.unique(qobs1)) == 1
+    ):  # if array has the same values, standard deviation become zero, causing "divide by zero" issue
+        error_metric = np.nan
+    else:
+        error_metric = np.corrcoef(qsim1, qobs1)[0, 1]
+    return error_metric
+
+
 def pbias(qsim, qobs):
     """
     Calculates percentage bias between two flow arrays.
@@ -47,9 +75,12 @@ def pbias(qsim, qobs):
     pbial: float
         percentage bias calculated between the two arrays.
     """
-
     qsim1, qobs1 = remove_nan(qsim, qobs)
-    return np.sum(qsim1 - qobs1) / np.sum(qobs1) * 100
+    if qobs1.size == 0:
+        error_metric = np.nan
+    else:
+        error_metric = np.sum(qsim1 - qobs1) / np.sum(qobs1) * 100
+    return error_metric
 
 
 def rmse(qsim, qobs):
@@ -68,4 +99,8 @@ def rmse(qsim, qobs):
         rmse calculated between the two arrays.
     """
     qsim1, qobs1 = remove_nan(qsim, qobs)
-    return np.sqrt(np.mean((qsim1 - qobs1) ** 2))
+    if qobs1.size == 0:
+        error_metric = np.nan
+    else:
+        error_metric = np.sqrt(np.mean((qsim1 - qobs1) ** 2))
+    return error_metric


### PR DESCRIPTION
### Description of changes:
* [x] Please add an explanation of what your changes do and why you'd like us to include them.

If there is observation available at river gauge sites for the evaluation (or simulation) period (the flow observation exist from 1900-2018. availability depends on sites and time), a few error metrics are computed in this notebook. There are many cases where obs are not available at sites due to inconsistent obs availability. This cause invalid math operation (divided by zero or try to compute with empty array, etc.) for some of metrics like correlation, percent bias. 

This PR include the detection of such cases in the functions in metrics.py, and put NaN for results and avoid numpy warning.
 
Tested my old notebooks that actually compare simulation and observations. Also with this PR, cupid still runs.

Resolve #140

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally?
