### PR TITLE
Cesm_postprocessing.sh flags are single dashes & abbreviated comp names

### DIFF
--- a/helper_scripts/cesm_postprocessing.sh
+++ b/helper_scripts/cesm_postprocessing.sh
@@ -52,22 +52,22 @@ cd cupid-postprocessing
 CUPID_FLAG_STRING=""
 if [ "${CUPID_RUN_ALL}" == "FALSE" ]; then
   if [ "${CUPID_RUN_ATM}" == "TRUE" ]; then
-    CUPID_FLAG_STRING+=" --atm"
+    CUPID_FLAG_STRING+=" -atm"
   fi
   if [ "${CUPID_RUN_OCN}" == "TRUE" ]; then
-    CUPID_FLAG_STRING+=" --ocn"
+    CUPID_FLAG_STRING+=" -ocn"
   fi
   if [ "${CUPID_RUN_LND}" == "TRUE" ]; then
-    CUPID_FLAG_STRING+=" --lnd"
+    CUPID_FLAG_STRING+=" -lnd"
   fi
   if [ "${CUPID_RUN_ICE}" == "TRUE" ]; then
-    CUPID_FLAG_STRING+=" --ice"
+    CUPID_FLAG_STRING+=" -ice"
   fi
   if [ "${CUPID_RUN_ROF}" == "TRUE" ]; then
-    CUPID_FLAG_STRING+=" --rof"
+    CUPID_FLAG_STRING+=" -rof"
   fi
   if [ "${CUPID_RUN_GLC}" == "TRUE" ]; then
-    CUPID_FLAG_STRING+=" --glc"
+    CUPID_FLAG_STRING+=" -glc"
   fi
   if [ "${CUPID_FLAG_STRING}" == "" ]; then
     echo "If CUPID_RUN_ALL is False, user must set at least one component"


### PR DESCRIPTION
### Description of changes:
* This PR resolves a bug resulting from using double dashes and abbreviated component names; now, we just use single dashes and abbreviated component names (this could be e.g. either `-atm` or `--atmosphere`).

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally?