### PR TITLE
Bug fixes: base 10 year bash fix and start date ts file fix

### DIFF
--- a/helper_scripts/cesm_postprocessing.sh
+++ b/helper_scripts/cesm_postprocessing.sh
@@ -10,9 +10,10 @@
 # is formatted as YYYY-MM-DD and print out the updated
 # string in the same format
 add_years() {
-  YEAR=`echo $1 | cut -d '-' -f 1`
-  MM=`echo $1 | cut -d '-' -f 2`
-  DD=`echo $1 | cut -d '-' -f 3`
+  IFS='-' read -r YEAR MM DD <<< "$1"
+  YEAR=$((10#$YEAR))  # Force base-10
+  MM=$((10#$MM))
+  DD=$((10#$DD))
   NEW_YEAR=`printf '%04d' "$((YEAR + $2))"`-`printf '%02d' "${MM}"`-`printf '%02d' "${DD}"`
   echo ${NEW_YEAR}
 }

--- a/helper_scripts/generate_cupid_config_for_cesm_case.py
+++ b/helper_scripts/generate_cupid_config_for_cesm_case.py
@@ -175,6 +175,16 @@ def generate_cupid_config(
                 cupid_end_year,
                 cupid_base_end_year,
             ]
+        if (
+            isinstance(my_dict["timeseries"][component], dict)
+            and "start_years" in my_dict["timeseries"][component]
+        ):
+            cupid_start_year = int(cupid_startdate.split("-")[0])
+            cupid_base_start_year = int(cupid_base_startdate.split("-")[0])
+            my_dict["timeseries"][component]["start_years"] = [
+                cupid_start_year,
+                cupid_base_start_year,
+            ]
     if "link_to_ADF" in my_dict["compute_notebooks"].get("atm", {}):
         my_dict["compute_notebooks"]["atm"]["link_to_ADF"]["parameter_groups"]["none"][
             "adf_root"


### PR DESCRIPTION
### Description of changes:
This addresses 2 bugs:
1) the bash script for adding years treats years as base 8 if they have zeroes in front of them, so the addition of years had unexpected results AND did not accept years that included individual integers greater than 8 (eg, year 0081 or 0009).
2) The start date for timeseries generation was defaulting to year 0001 rather than using the expected start date.

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally?
