### PR TITLE
Docs rm ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Usage: cupid-diagnostics [OPTIONS] CONFIG_PATH
 
 Options:
   -s, --serial        Do not use LocalCluster objects
-  -ts, --time-series  Run time series generation scripts prior to diagnostics
   -atm, --atmosphere  Run atmosphere component diagnostics
   -ocn, --ocean       Run ocean component diagnostics
   -lnd, --land        Run land component diagnostics

--- a/helper_scripts/cesm_postprocessing.sh
+++ b/helper_scripts/cesm_postprocessing.sh
@@ -45,6 +45,12 @@ CUPID_RUN_ADF=`./xmlquery --value CUPID_RUN_ADF`
 CUPID_INFRASTRUCTURE_ENV=`./xmlquery --value CUPID_INFRASTRUCTURE_ENV`
 CUPID_ANALYSIS_ENV=`./xmlquery --value CUPID_ANALYSIS_ENV`
 
+# Make sure environments are installed
+FOUND=TRUE; conda activate cupid-infrastructure 2>/dev/null || FOUND=FALSE
+mamba env create -f environments/cupid-infrastructure.yml
+conda activate cupid-infrastructure
+mamba env create -f environments/cupid-analysis.yml
+
 # Create directory for running CUPiD
 mkdir -p cupid-postprocessing
 cd cupid-postprocessing


### PR DESCRIPTION
### Description of changes:
* Currently the README documentation shows a `-ts` flag in the description for `cupid-diagnostics`, but this has been changed so that we use `cupid-timeseries` isntead.

The real options should be as follows:
Options:
  -s, --serial          Do not use LocalCluster objects
  -atm, --atmosphere    Run atmosphere component diagnostics
  -ocn, --ocean         Run ocean component diagnostics
  -lnd, --land          Run land component diagnostics
  -ice, --seaice        Run sea ice component diagnostics
  -glc, --landice       Run land ice component diagnostics
  -rof, --river-runoff  Run river runoff component diagnostics
  -h, --help            Show this message and exit.

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally when running standalone CUPiD?

Thanks to Yanchun He for pointing this out!