### PR TITLE
Add new test to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+  - repo: local
+    hooks:
+      - id: numeric-execution-count
+        name: numeric-execution-count
+        entry: bash -c '! (find nblibrary -name "*.ipynb" | xargs grep -l "execution_count.*[0-9]" && echo "ERROR need to clean notebooks listed above")'
+        language: system
+        pass_filenames: false
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:


### PR DESCRIPTION
### Description of changes:
If any notebook in nblibrary has a numeric `execution_count`,this check will fail. Uses the `bash` command:

```bash
! (find nblibrary -name "*.ipynb" | xargs grep -l "execution_count.*[0-9]" && echo "ERROR need to clean notebooks listed above")
```

`find nblibrary -name "*.ipynb" | xargs grep -l "execution_count.*[0-9]"` will find any notebooks with a numeric execution count and list the file names; `grep` returns `0` if it finds a match, so `&& echo "ERROR need to clean notebooks listed above"` prints the additional ERROR message below the line. Since `grep` returns `1` if no match is found, putting the whole command in `!(...)` returns `0` when no match is found (we want "no numeric execution counts" to be considered success) and `1` if `grep` matches anything.

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally when running standalone CUPiD?
* [x] Have you tested your changes as part of the CESM workflow?

Fixes #235 