### PR TITLE
Two quick fixes for bugs in recent PR

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,9 +14,8 @@ import os
 import re
 import sys
 
+sys.path.insert(0, os.path.abspath(".."))
 import cupid
-
-sys.path.insert(0, os.path.abspath("../.."))
 
 print("sys.path:", sys.path)
 print(f"cupid: {cupid.__file__}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,5 +46,5 @@ documentation = "https://nbscuid.readthedocs.io"
 [project.scripts]
 cupid-timeseries = "cupid.run_timeseries:run_timeseries"
 cupid-diagnostics = "cupid.run_diagnostics:run_diagnostics"
-cupid-webpage = "cupid.cupid_webpage:build"
+cupid-webpage = "cupid.generate_webpage:build"
 cupid-clean = "cupid.clean:clean"


### PR DESCRIPTION
1. We renamed `cupid-webpage` to `generate-webpage`, but did not update `pyproject.toml` so users running `cupid-webpage` from a fresh install of `cupid-infrastructure` will get an import error
2. The `conf.py` script should set the path before importing CUPiD so regardless of where you installed `(cupid-docs)` running `make html` from any `CUPID_ROOT/docs` directory will generate the documentation for the version of CUPiD in `CUPID_ROOT`

Fixes #239 

### Description of changes:
* [ ] Please add an explanation of what your changes do and why you'd like us to include them.

#### All PRs Checklist:
* [ ] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [ ] Have you successfully tested your changes locally when running standalone CUPiD?
* [ ] Have you tested your changes as part of the CESM workflow?
