### PR TITLE
Add CUPID_ROOT to env_postprocessing.xml

### DIFF
--- a/cime_config/config_tool.xml
+++ b/cime_config/config_tool.xml
@@ -4,7 +4,15 @@
 
 <entry_id version="3.0">
 
-  <!-- Variables that configure which part(s) of CUPiD are run -->
+  <!-- Variables that configure where to find CUPiD which part(s) of CUPiD are run -->
+
+  <entry id="CUPID_ROOT">
+    <type>char</type>
+    <default_value>$SRCROOT/tools/CUPiD</default_value>
+    <group>cupid_config</group>
+    <file>env_postprocessing.xml</file>
+    <desc>Location of CUPiD for CESM workflow</desc>
+  </entry>
 
   <entry id="CUPID_GEN_TIMESERIES">
     <type>char</type>

--- a/helper_scripts/cesm_postprocessing.sh
+++ b/helper_scripts/cesm_postprocessing.sh
@@ -21,7 +21,12 @@ add_years() {
 # Set variables that come from environment or CESM XML files
 CASEROOT=${PWD}
 SRCROOT=`./xmlquery --value SRCROOT`
+CESM_CUPID=${SRCROOT}/tools/CUPiD
 CUPID_ROOT=`./xmlquery --value CUPID_ROOT`
+
+if [ "${CUPID_ROOT}" != "${CESM_CUPID}" ]; then
+  echo "Note: Running CUPiD from ${CUPID_ROOT}, not ${CESM_CUPID}"
+fi
 CUPID_EXAMPLE=`./xmlquery --value CUPID_EXAMPLE`
 CUPID_GEN_TIMESERIES=`./xmlquery --value CUPID_GEN_TIMESERIES`
 CUPID_GEN_DIAGNOSTICS=`./xmlquery --value CUPID_GEN_DIAGNOSTICS`

--- a/helper_scripts/cesm_postprocessing.sh
+++ b/helper_scripts/cesm_postprocessing.sh
@@ -21,6 +21,7 @@ add_years() {
 # Set variables that come from environment or CESM XML files
 CASEROOT=${PWD}
 SRCROOT=`./xmlquery --value SRCROOT`
+CUPID_ROOT=`./xmlquery --value CUPID_ROOT`
 CUPID_EXAMPLE=`./xmlquery --value CUPID_EXAMPLE`
 CUPID_GEN_TIMESERIES=`./xmlquery --value CUPID_GEN_TIMESERIES`
 CUPID_GEN_DIAGNOSTICS=`./xmlquery --value CUPID_GEN_DIAGNOSTICS`
@@ -95,7 +96,7 @@ unset PYTHONPATH
 conda activate ${CUPID_INFRASTRUCTURE_ENV}
 
 # 1. Generate CUPiD config file
-${SRCROOT}/tools/CUPiD/helper_scripts/generate_cupid_config_for_cesm_case.py \
+${CUPID_ROOT}/helper_scripts/generate_cupid_config_for_cesm_case.py \
    --cesm-root ${SRCROOT} \
    --case-root ${CASEROOT} \
    --adf-output-root ${PWD} \
@@ -110,31 +111,31 @@ ${SRCROOT}/tools/CUPiD/helper_scripts/generate_cupid_config_for_cesm_case.py \
 
 # 2. Generate ADF config file
 if [ "${CUPID_RUN_ADF}" == "TRUE" ]; then
-  ${SRCROOT}/tools/CUPiD/helper_scripts/generate_adf_config_file.py \
+  ${CUPID_ROOT}/helper_scripts/generate_adf_config_file.py \
      --cesm-root ${SRCROOT} \
      --cupid-config-loc . \
-     --adf-template ${SRCROOT}/tools/CUPiD/externals/ADF/config_amwg_default_plots.yaml \
+     --adf-template ${CUPID_ROOT}/externals/ADF/config_amwg_default_plots.yaml \
      --out-file adf_config.yml
 fi
 
 # 3. Generate timeseries files
 if [ "${CUPID_GEN_TIMESERIES}" == "TRUE" ]; then
-   ${SRCROOT}/tools/CUPiD/cupid/run_timeseries.py ${CUPID_FLAG_STRING}
+   ${CUPID_ROOT}/cupid/run_timeseries.py ${CUPID_FLAG_STRING}
 fi
 
 #4. Run ADF
 if [ "${CUPID_RUN_ADF}" == "TRUE" ]; then
   conda deactivate
   conda activate ${CUPID_ANALYSIS_ENV}
-  ${SRCROOT}/tools/CUPiD/externals/ADF/run_adf_diag adf_config.yml
+  ${CUPID_ROOT}/externals/ADF/run_adf_diag adf_config.yml
 fi
 
 # 5. Run CUPiD and build webpage
 conda deactivate
 conda activate ${CUPID_INFRASTRUCTURE_ENV}
 if [ "${CUPID_GEN_DIAGNOSTICS}" == "TRUE" ]; then
-  ${SRCROOT}/tools/CUPiD/cupid/run_diagnostics.py ${CUPID_FLAG_STRING}
+  ${CUPID_ROOT}/cupid/run_diagnostics.py ${CUPID_FLAG_STRING}
 fi
 if [ "${CUPID_GEN_HTML}" == "TRUE" ]; then
-  ${SRCROOT}/tools/CUPiD/cupid/generate_webpage.py
+  ${CUPID_ROOT}/cupid/generate_webpage.py
 fi

--- a/helper_scripts/cesm_postprocessing.sh
+++ b/helper_scripts/cesm_postprocessing.sh
@@ -23,10 +23,6 @@ CASEROOT=${PWD}
 SRCROOT=`./xmlquery --value SRCROOT`
 CESM_CUPID=${SRCROOT}/tools/CUPiD
 CUPID_ROOT=`./xmlquery --value CUPID_ROOT`
-
-if [ "${CUPID_ROOT}" != "${CESM_CUPID}" ]; then
-  echo "Note: Running CUPiD from ${CUPID_ROOT}, not ${CESM_CUPID}"
-fi
 CUPID_EXAMPLE=`./xmlquery --value CUPID_EXAMPLE`
 CUPID_GEN_TIMESERIES=`./xmlquery --value CUPID_GEN_TIMESERIES`
 CUPID_GEN_DIAGNOSTICS=`./xmlquery --value CUPID_GEN_DIAGNOSTICS`
@@ -52,6 +48,10 @@ CUPID_RUN_ADF=`./xmlquery --value CUPID_RUN_ADF`
 CUPID_INFRASTRUCTURE_ENV=`./xmlquery --value CUPID_INFRASTRUCTURE_ENV`
 CUPID_ANALYSIS_ENV=`./xmlquery --value CUPID_ANALYSIS_ENV`
 
+# Note if CUPID_ROOT is not tools/CUPiD
+if [ "${CUPID_ROOT}" != "${CESM_CUPID}" ]; then
+  echo "Note: Running CUPiD from ${CUPID_ROOT}, not ${CESM_CUPID}"
+fi
 # Create directory for running CUPiD
 mkdir -p cupid-postprocessing
 cd cupid-postprocessing

--- a/helper_scripts/cesm_postprocessing.sh
+++ b/helper_scripts/cesm_postprocessing.sh
@@ -49,7 +49,8 @@ CUPID_INFRASTRUCTURE_ENV=`./xmlquery --value CUPID_INFRASTRUCTURE_ENV`
 CUPID_ANALYSIS_ENV=`./xmlquery --value CUPID_ANALYSIS_ENV`
 
 # Note if CUPID_ROOT is not tools/CUPiD
-if [ "${CUPID_ROOT}" != "${CESM_CUPID}" ]; then
+# (but don't complain if user adds a trailing "/")
+if [ "${CUPID_ROOT%/}" != "${CESM_CUPID}" ]; then
   echo "Note: Running CUPiD from ${CUPID_ROOT}, not ${CESM_CUPID}"
 fi
 # Create directory for running CUPiD

--- a/helper_scripts/cesm_postprocessing.sh
+++ b/helper_scripts/cesm_postprocessing.sh
@@ -118,7 +118,6 @@ ${CUPID_ROOT}/helper_scripts/generate_cupid_config_for_cesm_case.py \
 # 2. Generate ADF config file
 if [ "${CUPID_RUN_ADF}" == "TRUE" ]; then
   ${CUPID_ROOT}/helper_scripts/generate_adf_config_file.py \
-     --cesm-root ${SRCROOT} \
      --cupid-config-loc . \
      --adf-template ${CUPID_ROOT}/externals/ADF/config_amwg_default_plots.yaml \
      --out-file adf_config.yml

--- a/helper_scripts/cesm_postprocessing.sh
+++ b/helper_scripts/cesm_postprocessing.sh
@@ -97,8 +97,9 @@ conda activate ${CUPID_INFRASTRUCTURE_ENV}
 
 # 1. Generate CUPiD config file
 ${CUPID_ROOT}/helper_scripts/generate_cupid_config_for_cesm_case.py \
-   --cesm-root ${SRCROOT} \
    --case-root ${CASEROOT} \
+   --cesm-root ${SRCROOT} \
+   --cupid-root ${CUPID_ROOT} \
    --adf-output-root ${PWD} \
    --cupid-example ${CUPID_EXAMPLE} \
    --cupid-baseline-case ${CUPID_BASELINE_CASE} \

--- a/helper_scripts/generate_adf_config_file.py
+++ b/helper_scripts/generate_adf_config_file.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-import sys
 
 import click
 import yaml
@@ -11,15 +10,9 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
-@click.option("--cesm-root", required=True, help="Location of CESM source code")
-@click.option(
-    "--cupid-root",
-    default=None,
-    help="CUPiD directory (None => CESM_ROOT/tools/CUPiD)",
-)
 @click.option(
     "--cupid-config-loc",
-    default=None,
+    required=True,
     help="CUPiD example to use as template for config.yml",
 )
 @click.option(
@@ -29,8 +22,6 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 )
 @click.option("--out-file", required=True, help="the output file to save")
 def generate_adf_config(
-    cesm_root,
-    cupid_root,
     cupid_config_loc,
     adf_template,
     out_file,
@@ -38,13 +29,6 @@ def generate_adf_config(
     """Use cupid config file (YAML) from cupid_config_loc and adf_template (YAML)
     to produce out_file by modifying adf_template with data from cupid config file.
     """
-    sys.path.append(os.path.join(cesm_root, "cime"))
-
-    if cupid_root is None:
-        cupid_root = os.path.join(cesm_root, "tools", "CUPiD")
-    # Is cupid_config_loc a valid value?
-    if cupid_config_loc is None:
-        cupid_config_loc = os.path.join(cupid_root, "examples", "key_metrics")
     if not os.path.exists(os.path.join(cupid_config_loc, "config.yml")):
         raise KeyError(f"Can not find config.yml in {cupid_config_loc}")
 
@@ -60,7 +44,10 @@ def generate_adf_config(
     test_case_name = c_dict["global_params"]["case_name"]
     c_ts = c_dict["timeseries"]
     ts_case_names = c_ts.get("case_name")
-    ts_dir = os.path.join(c_dict["global_params"].get("ts_dir", CESM_output_dir))
+    ts_dir = c_dict["global_params"].get("ts_dir")
+    if ts_dir is None:
+        ts_dir = CESM_output_dir
+    ts_dir = os.path.join(ts_dir)
     if not ts_case_names:
         raise ValueError("CUPiD file does not have timeseries case_name array.")
 
@@ -242,7 +229,6 @@ def generate_adf_config(
         )
         f.write(f"# It is based off of {cupid_config_loc}/config.yml\n")
         f.write("# Arguments:\n")
-        f.write(f"# {cesm_root=}\n")
         f.write(f"# {cupid_config_loc=}\n")
         f.write(f"# {adf_template=}\n")
         f.write(f"# Output: {out_file=}\n")

--- a/helper_scripts/generate_adf_config_file.py
+++ b/helper_scripts/generate_adf_config_file.py
@@ -13,6 +13,11 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option("--cesm-root", required=True, help="Location of CESM source code")
 @click.option(
+    "--cupid-root",
+    default=None,
+    help="CUPiD directory (None => CESM_ROOT/tools/CUPiD)",
+)
+@click.option(
     "--cupid-config-loc",
     default=None,
     help="CUPiD example to use as template for config.yml",
@@ -23,13 +28,20 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     help="an adf config file to use as a base",
 )
 @click.option("--out-file", required=True, help="the output file to save")
-def generate_adf_config(cesm_root, cupid_config_loc, adf_template, out_file):
+def generate_adf_config(
+    cesm_root,
+    cupid_root,
+    cupid_config_loc,
+    adf_template,
+    out_file,
+):
     """Use cupid config file (YAML) from cupid_config_loc and adf_template (YAML)
     to produce out_file by modifying adf_template with data from cupid config file.
     """
     sys.path.append(os.path.join(cesm_root, "cime"))
 
-    cupid_root = os.path.join(cesm_root, "tools", "CUPiD")
+    if cupid_root is None:
+        cupid_root = os.path.join(cesm_root, "tools", "CUPiD")
     # Is cupid_config_loc a valid value?
     if cupid_config_loc is None:
         cupid_config_loc = os.path.join(cupid_root, "examples", "key_metrics")

--- a/helper_scripts/generate_cupid_config_for_cesm_case.py
+++ b/helper_scripts/generate_cupid_config_for_cesm_case.py
@@ -14,6 +14,11 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 @click.option("--cesm-root", required=True, help="Location of CESM source code")
 @click.option("--case-root", default=os.getcwd(), help="CESM case directory")
 @click.option(
+    "--cupid-root",
+    default=None,
+    help="CUPiD directory (None => CESM_ROOT/tools/CUPiD)",
+)
+@click.option(
     "--cupid-example",
     default="key_metrics",
     help="CUPiD example to use as template for config.yml",
@@ -53,6 +58,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 def generate_cupid_config(
     case_root,
     cesm_root,
+    cupid_root,
     cupid_example,
     cupid_baseline_case,
     cupid_baseline_root,
@@ -84,7 +90,10 @@ def generate_cupid_config(
         The root directory of the CESM case from which case-specific data will be retrieved.
 
     cesm_root : str
-        The root directory of the CESM installation, where CIME scripts and CUPiD examples reside.
+        The root directory of the CESM installation, where CIME scripts reside.
+
+    cupid_root : str
+        The root directory where CUPiD examples reside (defaults to subdirectory of cesm_root).
 
     cupid_example : str
         The name of a CUPiD example (e.g., 'key metrics') to base the configuration file on.
@@ -131,7 +140,8 @@ def generate_cupid_config(
         adf_output_root = case_root
 
     # Is cupid_example a valid value?
-    cupid_root = os.path.join(cesm_root, "tools", "CUPiD")
+    if cupid_root is None:
+        cupid_root = os.path.join(cesm_root, "tools", "CUPiD")
     cupid_examples = os.path.join(cupid_root, "examples")
     valid_examples = [
         example

--- a/nblibrary/atm/link_to_ADF.ipynb
+++ b/nblibrary/atm/link_to_ADF.ipynb
@@ -14,7 +14,7 @@
     "1) Install ADF and activate cupid-analysis\n",
     "2) Use the `CUPiD/helper_scripts/generate_adf_config_file.py` script to generate an ADF config file based on a CUPiD configuration file.\n",
     "   * `cd CUPiD/examples/external_diag_packages`\n",
-    "   * `../../helper_scripts/generate_adf_config_file.py --cesm-root $CESM_ROOT --cupid-config-loc . --adf-template ../../externals/ADF/config_amwg_default_plots.yaml --out-file ADF_config.yaml`\n",
+    "   * `../../helper_scripts/generate_adf_config_file.py --cupid-config-loc . --adf-template ../../externals/ADF/config_amwg_default_plots.yaml --out-file ADF_config.yaml`\n",
     "3) Run ADF with the newly created configuration file.\n",
     "   * `../../externals/ADF/run_adf_diag ADF_config.yaml`"
    ]


### PR DESCRIPTION
### Description of changes:

CESM users should be able to set `CUPID_ROOT` via `xmlchange` rather than being tied to the version of CUPiD available in their CESM sandbox.

Fixes #257 

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally when running standalone CUPiD?
* [x] Have you tested your changes as part of the CESM workflow?
* [x] Once you are ready to have your PR reviewed, have you changed it from a Draft PR to an Open PR?

