### PR TITLE
Include Notebook for Intermediary CESM Output Diagnostics

### DIFF
--- a/cupid_utils/cupid_utils/multi-component/spatial_means.py
+++ b/cupid_utils/cupid_utils/multi-component/spatial_means.py
@@ -4,39 +4,6 @@ import xarray as xr
 import numpy as np
 
 
-def fix_time_variable(ds):
-    """
-    Description: fix the time of cam file to have the time at
-       the middle of the interval instead of the end the interval.
-    Argument:
-       ds: dataset
-    Return:
-       ds: dataset with the time variable at the middle of interval.
-    """
-    time = ds["time"]
-    time = xr.DataArray(
-        ds["time_bnds"].load().mean(dim="nbnd").values,
-        dims=time.dims,
-        attrs=time.attrs,
-    )
-    ds["time"] = time
-    ds.assign_coords(time=time)
-    return ds
-
-
-def ann_mean(ds):
-    """
-    Description: compute the annual mean of a monthly mean dataset
-    Argument:
-       ds: dataset "
-    Return:
-       ds_ann: annual mean
-    """
-    ds_gb = ds.groupby("time.year")
-    ds_ann = ds_gb.mean()
-    return ds_ann
-
-
 def global_mean(variable):
     """
     Description: compute the global mean (weigthed) of a variable
@@ -46,9 +13,35 @@ def global_mean(variable):
        ds_ann: annual mean
     """
     weights = np.cos(np.deg2rad(variable.lat))
-    variable_weigthed = variable.weighted(weights)
-    variable_mean = variable_weigthed.mean(("lon", "lat"))
+    variable_weighted = variable.weighted(weights)
+    variable_mean = variable_weighted.mean(("lon", "lat"))
     return variable_mean
+
+
+def compute_ann_mean(filepath, case, var, lat1=None, lat2=None, lon1=None, lon2=None):
+    """
+    Description: Compute the annual mean within a specified latitude (lat1-lat2)
+    and longitude (lon1-lon2) range of the variable "var".
+
+    Arguments:
+        filepath = filepath
+        case = casename
+        var = variable name
+        lat1 = starting latitude
+        lat2 = ending latitude
+        lon1 = starting longitude
+        lon2 = ending longitude
+    """
+    filename = filepath + case + "/" + case + "." + var + ".nc"
+    ds = xr.open_dataset(filename)
+
+    # Select the subset of data within the specified latitude and longitude ranges before calculating the annual mean
+    ds_subset = ds.sel(lat=slice(lat1, lat2), lon=slice(lon1, lon2))
+
+    var_ann = ds_subset[var].groupby("time.year").mean()
+    var_lat_lon_ann = lat_lon_mean(var_ann, lat1, lat2, lon1, lon2)
+
+    return var_lat_lon_ann
 
 
 def compute_var_g_ann(filepath, case, var):
@@ -61,11 +54,7 @@ def compute_var_g_ann(filepath, case, var):
     """
     filename = filepath + case + "/" + case + "." + var + ".nc"
     ds = xr.open_dataset(filename)
-
-    ds.mean(["lat", "time"])
-    var_ann = ann_mean(ds[var])
-    var_g_ann = global_mean(var_ann)
-    return var_g_ann
+    return global_mean(ds[var].groupby("time.year").mean())
 
 
 def lat_lon_mean(variable, lat1, lat2, lon1, lon2):
@@ -122,35 +111,10 @@ def lat_lon_mean_norm(variable, lat1, lat2, lon1, lon2):
     weights /= weights.sum(dim="lat")
 
     # Apply weighted mean over the subset
-    variable_weigthed = variable_subset.weighted(weights)
-    variable_mean = variable_weigthed.mean(("lon", "lat"))
+    variable_weighted = variable_subset.weighted(weights)
+    variable_mean = variable_weighted.mean(("lon", "lat"))
 
     return variable_mean
-
-
-def compute_var_lat_lon_ann(filepath, case, var, lat1, lat2, lon1, lon2):
-    """
-    Description: Compute the annual mean within a specified latitude (lat1-lat2)
-    and longitude (lon1-lon2) range of the variable "var".
-
-    Arguments:
-       case = casename
-       var = variable name
-       lat1 = starting latitude
-       lat2 = ending latitude
-       lon1 = starting longitude
-       lon2 = ending longitude
-    """
-    filename = filepath + case + "/" + case + "." + var + ".nc"
-    ds = xr.open_dataset(filename)
-
-    # Select the subset of data within the specified latitude and longitude ranges before calculating the annual mean
-    ds_subset = ds.sel(lat=slice(lat1, lat2), lon=slice(lon1, lon2))
-
-    var_ann = ann_mean(ds_subset[var])
-    var_lat_lon_ann = lat_lon_mean(var_ann, lat1, lat2, lon1, lon2)
-
-    return var_lat_lon_ann
 
 
 def compute_var_zonal_ann(filepath, case, var):
@@ -164,5 +128,5 @@ def compute_var_zonal_ann(filepath, case, var):
     filename = filepath + case + "/" + case + "." + var + ".nc"
     ds = xr.open_dataset(filename)
     ds.mean(["lon"])
-    var_zonal_ann = ann_mean(ds[var]).mean(["lon"])
+    var_zonal_ann = ds[var].groupby("time.year").mean().mean(["lon"])
     return var_zonal_ann

--- a/examples/intermediary_outputs/config.yml
+++ b/examples/intermediary_outputs/config.yml
@@ -46,15 +46,6 @@ global_params: # TODO: a lot of these params may be irrelevant/misleading for th
   case_nickname: 'BLT1850_232'
   base_case_nickname: 'BLT1850_228'
   CESM_output_dir: /glade/campaign/cesm/development/cross-wg/diagnostic_framework/CESM_output_for_testing
-  start_date: '0001-01-01'
-  end_date: '0021-01-01'
-  climo_start_year: 11
-  climo_end_year: 21
-  base_start_date: '0001-01-01'
-  base_end_date: '0045-01-01'
-  base_climo_start_year: 36
-  base_climo_end_year: 45
-  obs_data_dir: '/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data'
   ts_dir: null # If this is set to null, it will default to CESM_output_dir; if you don't have permissions to write to CESM_output_dir, you can specify a directory such as your scratch arcive directory
   lc_kwargs:
     threads_per_worker: 1

--- a/nblibrary/atm/Global_TS_RESTOM_tseries.ipynb
+++ b/nblibrary/atm/Global_TS_RESTOM_tseries.ipynb
@@ -26,7 +26,7 @@
     "import math\n",
     "import os\n",
     "\n",
-    "import cupid_utils.generic_fxns as gfxns\n",
+    "import cupid_utils.multi_component.spatial_means as spmeans\n",
     "\n",
     "# Suppress Cartopy warnings (safe to keep even if Cartopy is not used)\n",
     "warnings.filterwarnings(\"ignore\")"
@@ -50,7 +50,8 @@
     "base_case_output_dir = None\n",
     "base_case_name = None\n",
     "base_case_nickname = None\n",
-    "vars = []"
+    "vars = []\n",
+    "ts_dir = None"
    ]
   },
   {
@@ -67,7 +68,9 @@
     "# Want base case dir to default to control case value\n",
     "if base_case_name is not None:\n",
     "    if base_case_output_dir is None:\n",
-    "        base_case_output_dir = CESM_output_dir"
+    "        base_case_output_dir = ts_dir\n",
+    "if ts_dir is None:\n",
+    "    ts_dir = CESM_output_dir"
    ]
   },
   {
@@ -96,7 +99,7 @@
     "        \"label\": case_nickname,\n",
     "        \"offset\": 0,  # TODO: make configurable\n",
     "        \"descr\": \"case\",\n",
-    "        \"path\": CESM_output_dir,\n",
+    "        \"path\": ts_dir,\n",
     "    },\n",
     "    base_case_name: {\n",
     "        \"label\": base_case_nickname,\n",
@@ -129,7 +132,7 @@
     "    for casename, info in cases.items():\n",
     "        label = info[\"label\"]\n",
     "        if vars[var] != \"Global\":\n",
-    "            regional_var[label] = gfxns.compute_var_lat_lon_ann(\n",
+    "            regional_var[label] = spmeans.compute_var_lat_lon_ann(\n",
     "                os.path.join(info[\"path\"], casename, \"atm/proc/tseries/\"),\n",
     "                casename,\n",
     "                var,\n",
@@ -140,14 +143,14 @@
     "            )\n",
     "        elif vars[var] == \"Global\":\n",
     "            if var != \"RESTOM\":\n",
-    "                regional_var[label] = gfxns.compute_var_g_ann(\n",
+    "                regional_var[label] = spmeans.compute_var_g_ann(\n",
     "                    os.path.join(info[\"path\"], casename, \"atm/proc/tseries/\"),\n",
     "                    casename,\n",
     "                    var,\n",
     "                )\n",
     "            elif var == \"RESTOM\":\n",
     "                regional_var[label] = (\n",
-    "                    gfxns.compute_var_g_ann(\n",
+    "                    spmeans.compute_var_g_ann(\n",
     "                        os.path.join(info[\"path\"], casename, \"atm/proc/tseries/\"),\n",
     "                        casename,\n",
     "                        var,\n",

--- a/nblibrary/ice/Lab_Sea_ICEFRAC_tseries.ipynb
+++ b/nblibrary/ice/Lab_Sea_ICEFRAC_tseries.ipynb
@@ -26,7 +26,7 @@
     "import math\n",
     "import os\n",
     "\n",
-    "import cupid_utils.generic_fxns as gfxns\n",
+    "import cupid_utils.multi_component.spatial_means as spmeans\n",
     "\n",
     "# Suppress Cartopy warnings (safe to keep even if Cartopy is not used)\n",
     "warnings.filterwarnings(\"ignore\")"
@@ -50,7 +50,8 @@
     "base_case_output_dir = None\n",
     "base_case_name = None\n",
     "base_case_nickname = None\n",
-    "vars = []"
+    "vars = []\n",
+    "ts_dir = None"
    ]
   },
   {
@@ -67,7 +68,9 @@
     "# Want base case dir to default to control case value\n",
     "if base_case_name is not None:\n",
     "    if base_case_output_dir is None:\n",
-    "        base_case_output_dir = CESM_output_dir"
+    "        base_case_output_dir = ts_dir\n",
+    "if ts_dir is None:\n",
+    "    ts_dir = CESM_output_dir"
    ]
   },
   {
@@ -96,7 +99,7 @@
     "        \"label\": case_nickname,\n",
     "        \"offset\": 0,  # TODO: make configurable\n",
     "        \"descr\": \"case\",\n",
-    "        \"path\": CESM_output_dir,\n",
+    "        \"path\": ts_dir,\n",
     "    },\n",
     "    base_case_name: {\n",
     "        \"label\": base_case_nickname,\n",
@@ -130,7 +133,7 @@
     "    for casename, info in cases.items():\n",
     "        label = info[\"label\"]\n",
     "        if vars[var] != \"Global\":\n",
-    "            regional_var[label] = gfxns.compute_var_lat_lon_ann(\n",
+    "            regional_var[label] = spmeans.compute_var_lat_lon_ann(\n",
     "                os.path.join(info[\"path\"], casename, \"ice/proc/tseries/\"),\n",
     "                casename,\n",
     "                var,\n",
@@ -140,7 +143,7 @@
     "                region[3],\n",
     "            )\n",
     "        elif vars[var] == \"Global\":\n",
-    "            regional_var[label] = gfxns.compute_var_g_ann(\n",
+    "            regional_var[label] = spmeans.compute_var_g_ann(\n",
     "                os.path.join(info[\"path\"], casename, \"ice/proc/tseries/\"), casename, var\n",
     "            )\n",
     "        variable_data[var] = regional_var"


### PR DESCRIPTION
### Description of changes:
This PR will include a notebook from @cecilehannay that will be a good notebook to look at CESM output during model runs. 
We will still need to do the following:
* [x] Update notebook to use parameters from config file
* [x] pull utils out of notebook
* [x] Either break notebook up into components or create an `intermediary_outputs` notebook directory under nblibrary (I decided breaking into components was the most straightforward, and additionally generalized in order to make it easy to add additional vars)
* [x] in a separate PR, we will want to include capability of running CUPiD intermittently during CESM run (not done yet, but documented in #343)
* [x] make an `intermediary_outputs` example
* [x] This notebook currently expects all tseries to be computed and in one dir (not component-separated). We will need to make sure that this is updated to match the cupid tseries output
* [x] make variables configurable / be able to add to subplots

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally when running standalone CUPiD?
* [x] Once you are ready to have your PR reviewed, have you changed it from a Draft PR to an Open PR?

#### New notebook PR Additional Checklist (if these do not apply, feel free to remove this section):
* [x] Have you [hidden the code cells (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html) in your notebook?
* [x] Have you removed any unused parameters from your cell tagged with `parameters`? These can cause confusing warnings that show up as `DAG build with warnings`.
