### PR TITLE
Update pyupgrade to avoid TypeError

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,9 @@ repos:
     -   id: add-trailing-comma
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 7.0.0


### PR DESCRIPTION
### Description of changes:
Older versions of `pyupgrade` raised `TypeErrors` starting in python 3.14.1 and the `setup-python` github action is giving us 3.14.2; rather than forcing github to use an older version of python, we moved to a version of `pyupgrade` that fixes the issue

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally when running standalone CUPiD?
* [x] Have you tested your changes as part of the CESM workflow?
* [x] Once you are ready to have your PR reviewed, have you changed it from a Draft PR to an Open PR?

Note: I didn't test updating `pyupgrade` but continuing to use an older version of python; if that causes problems, the solution will be to tell folks to update the version of python in the environment they use for `pre-commit` :)