### PR TITLE
Add cfunits to cupid-analysis environment

### DIFF
--- a/environments/cupid-analysis.yml
+++ b/environments/cupid-analysis.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - cartopy
   - cftime
+  - cfunits
   - dask
   - distributed
   - geocat-comp


### PR DESCRIPTION
### Description of changes:
In #348, @dabail10 reported a problem creating the `cupid-analysis` environment because `cfunits` wasn't installing correctly. This PR uses conda to install that package instead of pip.

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally when running standalone CUPiD?
* [x] Have you tested your changes as part of the CESM workflow?
* [x] Once you are ready to have your PR reviewed, have you changed it from a Draft PR to an Open PR?

Fixes #348
