### PR TITLE
Helper scripts convert relative paths to absolute

### DIFF
--- a/helper_scripts/generate_adf_config_file.py
+++ b/helper_scripts/generate_adf_config_file.py
@@ -32,6 +32,11 @@ def generate_adf_config(
     if not os.path.exists(os.path.join(cupid_config_loc, "config.yml")):
         raise KeyError(f"Can not find config.yml in {cupid_config_loc}")
 
+    helper_scripts_path = os.path.realpath(os.path.dirname(__file__))
+    adf_root = os.path.realpath(
+        os.path.join(helper_scripts_path, "..", "externals", "ADF"),
+    )
+
     with open(os.path.join(cupid_config_loc, "config.yml")) as c:
         c_dict = yaml.safe_load(c)
     with open(adf_template, encoding="UTF-8") as a:
@@ -253,7 +258,7 @@ def generate_adf_config(
         a_dict["diag_cvdp_info"] = cvdp_args
         a_dict["diag_cvdp_info"][
             "cvdp_codebase_loc"
-        ] = "../../externals/ADF/lib/externals/CVDP/"
+        ] = f"{adf_root}/lib/externals/CVDP/"
         # this is where CVDP code base lives in the ADF
 
         a_dict["diag_cvdp_info"]["cvdp_loc"] = os.path.join(

--- a/helper_scripts/generate_cupid_config_for_cesm_case.py
+++ b/helper_scripts/generate_cupid_config_for_cesm_case.py
@@ -313,6 +313,22 @@ def generate_cupid_config(
             "cvdp_loc"
         ] = os.path.join(adf_output_root, "CVDP_output")
 
+    if "LDF" in my_dict["compute_notebooks"].get("lnd", {}):
+        if "external_tool" not in my_dict["compute_notebooks"]["lnd"]["LDF"]:
+            my_dict["compute_notebooks"]["lnd"]["LDF"]["external_tool"] = {}
+        my_dict["compute_notebooks"]["lnd"]["LDF"]["external_tool"]["defaults_file"] = (
+            os.path.join(
+                cupid_root,
+                "externals",
+                "LDF",
+                "lib",
+                "ldf_variable_defaults.yaml",
+            )
+        )
+        my_dict["compute_notebooks"]["lnd"]["LDF"]["external_tool"]["regions_file"] = (
+            os.path.join(cupid_root, "externals", "LDF", "lib", "regions_lnd.yaml")
+        )
+
     if "Greenland_SMB_visual_compare_obs" in my_dict["compute_notebooks"].get(
         "glc",
         {},


### PR DESCRIPTION
### Description of changes:

`generate_cupid_config_for_cesm_case` sets LDF variables for `default_files` and `regions_file` based on `cupid_root` (in the examples directories we use `../../externals` but for CESM workflow that should be `{cupid_root}/externals`)

`generate_adf_config_file.py` does something similar for `cvdp_codebase_loc`

Fixes #369
Fixes #370

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally when running standalone CUPiD?
* [ ] Have you tested your changes as part of the CESM workflow?
* [x] Once you are ready to have your PR reviewed, have you changed it from a Draft PR to an Open PR?