### PR TITLE
Pin pandas to 2.3.3 in analysis env

### DIFF
--- a/environments/cupid-analysis.yml
+++ b/environments/cupid-analysis.yml
@@ -34,6 +34,7 @@ dependencies:
   - ncar-jobqueue=2021.4.14
   - netcdf4=1.7.3
   - numpy=2.2.6
+  - pandas=2.3.3
   - pip=25.3
   - pluggy=1.6.0
   - pytest=9.0.2


### PR DESCRIPTION
### Description of changes:
Pandas wasn't explicitly pinned, and recent environments were including 3.0.0 which was causing issues in `xr.Dataset.to_netcdf()`

Fixes #388

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally when running standalone CUPiD?
* [ ] Have you tested your changes as part of the CESM workflow?
* [x] Once you are ready to have your PR reviewed, have you changed it from a Draft PR to an Open PR?