### PR TITLE
fixing GLC jupyter notebook

### DIFF
--- a/examples/key_metrics/config.yml
+++ b/examples/key_metrics/config.yml
@@ -175,6 +175,7 @@ compute_notebooks:
           none:
             obs_path: 'glc/analysis_datasets/multi_grid/annual_avg/SMB_data'
             obs_name: 'GrIS_MARv3.12_climo_1960_1999.nc'
+            init_file: 'cism.gris.initial_hist.0001-01-01-00000.nc'
             climo_nyears: 40
 
     rof:

--- a/nblibrary/glc/Greenland_SMB_visual_compare_obs.ipynb
+++ b/nblibrary/glc/Greenland_SMB_visual_compare_obs.ipynb
@@ -90,7 +90,8 @@
     "\n",
     "obs_data_dir = \"\"  # global directory containing observed dataset\n",
     "obs_path = \"\"  # specific directory containing observed dataset\n",
-    "obs_name = \"\"  # file name for observed dataset"
+    "obs_name = \"\"  # file name for observed dataset\n",
+    "init_file = \"\" # initial conditions file (provides grid for interpolating obs)\""
    ]
   },
   {
@@ -137,9 +138,7 @@
    "source": [
     "last_year = int(end_date.split(\"-\")[0])\n",
     "\n",
-    "case_init_file = os.path.join(\n",
-    "    obs_data_dir, obs_path, \"cism.gris.initial_hist.0001-01-01-00000.nc\"\n",
-    ")  # name of glc file output\n",
+    "case_init_file = os.path.join(obs_data_dir, obs_path, init_file)  # name of glc file output\n",
     "\n",
     "case_path = os.path.join(\n",
     "    CESM_output_dir, case_name, \"cpl\", \"hist\"\n",
@@ -557,8 +556,19 @@
     "x_ticks = np.arange(full_time[0], full_time[-1] + 2, 5)\n",
     "tickx = x_ticks\n",
     "\n",
-    "ymin = 100\n",
-    "ymax = 600\n",
+    "print(f\"avg_smb_case_climo, has shape {np.shape(avg_smb_case_climo)}\")\n",
+    "print(f\"avg_smb_case_timeseries has shape {np.shape(avg_smb_case_timeseries)}\")\n",
+    "print(f\"avg_smb_base_case_climo has shape {np.shape(avg_smb_base_case_climo)}\")\n",
+    "print(f\"avg_smb_base_timeseries has shape {np.shape(avg_smb_base_timeseries)}\")\n",
+    "print(f\"avg_smb_obs_timeseries has shape {np.shape(avg_smb_obs_timeseries)}\")\n",
+    "\n",
+    "ymin1 = np.array([avg_smb_base_case_climo,avg_smb_base_timeseries,avg_smb_obs_timeseries]).min()\n",
+    "ymin2 = np.array([avg_smb_case_climo,avg_smb_case_timeseries]).min()\n",
+    "ymax1 = np.array([avg_smb_base_case_climo,avg_smb_base_timeseries,avg_smb_obs_timeseries]).max()\n",
+    "ymax2 = np.array([avg_smb_case_climo,avg_smb_case_timeseries]).max()\n",
+    "\n",
+    "ymin = np.array([ymin1,ymin2]).min()-50\n",
+    "ymax = np.array([ymax1,ymax2]).max()+50\n",
     "y_step = 50\n",
     "y_ticks = np.arange(ymin, ymax + y_step, y_step)\n",
     "\n",
@@ -624,9 +634,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cupid-analysis",
+   "display_name": "NPL 2025a",
    "language": "python",
-   "name": "cupid-analysis"
+   "name": "npl-2025a"
   },
   "language_info": {
    "codemirror_mode": {
@@ -638,7 +648,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/nblibrary/glc/Greenland_SMB_visual_compare_obs.ipynb
+++ b/nblibrary/glc/Greenland_SMB_visual_compare_obs.ipynb
@@ -640,9 +640,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "NPL 2025a",
+   "display_name": "cupid-analysis",
    "language": "python",
-   "name": "npl-2025a"
+   "name": "cupid-analysis"
   },
   "language_info": {
    "codemirror_mode": {
@@ -654,7 +654,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/nblibrary/glc/Greenland_SMB_visual_compare_obs.ipynb
+++ b/nblibrary/glc/Greenland_SMB_visual_compare_obs.ipynb
@@ -91,7 +91,7 @@
     "obs_data_dir = \"\"  # global directory containing observed dataset\n",
     "obs_path = \"\"  # specific directory containing observed dataset\n",
     "obs_name = \"\"  # file name for observed dataset\n",
-    "init_file = \"\" # initial conditions file (provides grid for interpolating obs)\""
+    "init_file = \"\"  # initial conditions file (provides grid for interpolating obs)\""
    ]
   },
   {
@@ -138,7 +138,9 @@
    "source": [
     "last_year = int(end_date.split(\"-\")[0])\n",
     "\n",
-    "case_init_file = os.path.join(obs_data_dir, obs_path, init_file)  # name of glc file output\n",
+    "case_init_file = os.path.join(\n",
+    "    obs_data_dir, obs_path, init_file\n",
+    ")  # name of glc file output\n",
     "\n",
     "case_path = os.path.join(\n",
     "    CESM_output_dir, case_name, \"cpl\", \"hist\"\n",
@@ -562,13 +564,17 @@
     "print(f\"avg_smb_base_timeseries has shape {np.shape(avg_smb_base_timeseries)}\")\n",
     "print(f\"avg_smb_obs_timeseries has shape {np.shape(avg_smb_obs_timeseries)}\")\n",
     "\n",
-    "ymin1 = np.array([avg_smb_base_case_climo,avg_smb_base_timeseries,avg_smb_obs_timeseries]).min()\n",
-    "ymin2 = np.array([avg_smb_case_climo,avg_smb_case_timeseries]).min()\n",
-    "ymax1 = np.array([avg_smb_base_case_climo,avg_smb_base_timeseries,avg_smb_obs_timeseries]).max()\n",
-    "ymax2 = np.array([avg_smb_case_climo,avg_smb_case_timeseries]).max()\n",
+    "ymin1 = np.array(\n",
+    "    [avg_smb_base_case_climo, avg_smb_base_timeseries, avg_smb_obs_timeseries]\n",
+    ").min()\n",
+    "ymin2 = np.array([avg_smb_case_climo, avg_smb_case_timeseries]).min()\n",
+    "ymax1 = np.array(\n",
+    "    [avg_smb_base_case_climo, avg_smb_base_timeseries, avg_smb_obs_timeseries]\n",
+    ").max()\n",
+    "ymax2 = np.array([avg_smb_case_climo, avg_smb_case_timeseries]).max()\n",
     "\n",
-    "ymin = np.array([ymin1,ymin2]).min()-50\n",
-    "ymax = np.array([ymax1,ymax2]).max()+50\n",
+    "ymin = np.array([ymin1, ymin2]).min() - 50\n",
+    "ymax = np.array([ymax1, ymax2]).max() + 50\n",
     "y_step = 50\n",
     "y_ticks = np.arange(ymin, ymax + y_step, y_step)\n",
     "\n",


### PR DESCRIPTION
- in config.yml, add the option for the init_file
- in the jupyter notebook, removed the hard coded dependency on the init_file, and fixed the range for plotting the time series.

### Description of changes:
* [x] Please add an explanation of what your changes do and why you'd like us to include them.

#### All PRs Checklist:
* [x] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [x] Have you successfully tested your changes locally when running standalone CUPiD?
* [ ] Have you tested your changes as part of the CESM workflow?
* [x] Once you are ready to have your PR reviewed, have you changed it from a Draft PR to an Open PR?

#### New notebook PR Additional Checklist (if these do not apply, feel free to remove this section):
* [ ] Have you [hidden the code cells (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html) in your notebook?
* [ ] Have you removed any unused parameters from your cell tagged with `parameters`? These can cause confusing warnings that show up as `DAG build with warnings`.
* [ ] Have you moved any observational data that you are using to `/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data` and ensured that it follows this format within that directory: `COMPONENT/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE`?
