### PR TITLE
Treat CUPID_REGRID=FALSE appropriately

### DIFF
--- a/helper_scripts/generate_cupid_config_for_cesm_case.py
+++ b/helper_scripts/generate_cupid_config_for_cesm_case.py
@@ -364,21 +364,24 @@ def generate_cupid_config(
             cupid_regrid_base_atm_file,
         ]
 
-    if cupid_regrid:
-        if "Global_PSL_NMSE_compare_obs_lens" in my_dict["compute_notebooks"].get(
-            "atm",
-            {},
-        ):
-            my_dict["compute_notebooks"]["atm"]["Global_PSL_NMSE_compare_obs_lens"][
-                "parameter_groups"
-            ]["none"]["regridded_output"] = (cupid_regrid_atm_file is not None)
-        if "TimeSeriesPlots" in my_dict["compute_notebooks"].get("atm", {}):
-            my_dict["compute_notebooks"]["atm"]["TimeSeriesPlots"]["parameter_groups"][
-                "none"
-            ]["regridded_output"] = (cupid_regrid_atm_file is not None)
-            my_dict["compute_notebooks"]["atm"]["TimeSeriesPlots"]["parameter_groups"][
-                "none"
-            ]["base_regridded_output"] = (cupid_regrid_base_atm_file is not None)
+    if "Global_PSL_NMSE_compare_obs_lens" in my_dict["compute_notebooks"].get(
+        "atm",
+        {},
+    ):
+        my_dict["compute_notebooks"]["atm"]["Global_PSL_NMSE_compare_obs_lens"][
+            "parameter_groups"
+        ]["none"]["regridded_output"] = cupid_regrid and (
+            cupid_regrid_atm_file is not None
+        )
+    if "TimeSeriesPlots" in my_dict["compute_notebooks"].get("atm", {}):
+        my_dict["compute_notebooks"]["atm"]["TimeSeriesPlots"]["parameter_groups"][
+            "none"
+        ]["regridded_output"] = cupid_regrid and (cupid_regrid_atm_file is not None)
+        my_dict["compute_notebooks"]["atm"]["TimeSeriesPlots"]["parameter_groups"][
+            "none"
+        ]["base_regridded_output"] = cupid_regrid and (
+            cupid_regrid_base_atm_file is not None
+        )
 
     if cupid_run_adf or cupid_run_ldf or cupid_run_ilamb:
         if "index" in my_dict["compute_notebooks"]["infrastructure"]:


### PR DESCRIPTION
Previously, when `CUPID_REGRID=FALSE`, both `regridded_output` and `base_regridded_output` were left unchanged by
`generate_cupid_config_for_cesm_case.py`; instead they should both have been set to `false` (and now they are)

Fixes #410 

### Description of changes:
* [ x ] Please add an explanation of what your changes do and why you'd like us to include them.

#### All PRs Checklist:
* [ x ] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ x ] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [ x ] Have you tested your changes as part of the CESM workflow?
* [ x ] Once you are ready to have your PR reviewed, have you changed it from a Draft PR to an Open PR?